### PR TITLE
Add functions to get settings from ckan config

### DIFF
--- a/ckantools/config.py
+++ b/ckantools/config.py
@@ -32,4 +32,4 @@ def get_debug(default=True):
     :param default: returns this if neither is set
     :return: True if debug mode is enabled
     """
-    return get_setting('debug', 'DEBUG', default=default)
+    return toolkit.asbool(get_setting('debug', 'DEBUG', default=default))


### PR DESCRIPTION
`get_setting` is essentially a way of avoiding this:
```python
toolkit.config.get('specific_setting', toolkit.config.get('backup_setting', toolkit.config.get('ckan_setting', 'banana')))
```

Which would then become:
```python
get_setting('specific_setting', 'backup_setting', 'ckan_setting', default='banana')
```

`get_debug` is a specific implementation of `get_setting` which checks multiple debug values (sometimes it's set as `debug`, sometimes `DEBUG`).